### PR TITLE
Fix default S3 configuration for alertmanagers and rulers

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -34,6 +34,7 @@ parameters:
       mimir:
         structuredConfig:
           alertmanager_storage:
+            backend: s3
             s3:
               bucket_name: ${mimir:name}-alertmanager-bucket
               access_key_id: \${S3_ACCESS_KEY_ID}
@@ -47,6 +48,7 @@ parameters:
               endpoint: \${S3_ENDPOINT}
               secret_access_key: \${S3_SECRET_ACCESS_KEY}
           ruler_storage:
+            backend: s3
             s3:
               bucket_name: ${mimir:name}-ruler-bucket
               access_key_id: \${S3_ACCESS_KEY_ID}

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/alertmanager/alertmanager-statefulset.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         bucketSecretVersion: '0'
         checksum/alertmanager-fallback-config: d7cc002124943a504c792ba298711410d73b0a974b149fc6920c045c425952c1
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: alertmanager
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/compactor/compactor-statefulset.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/compactor/compactor-statefulset.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: compactor
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/distributor/distributor-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/distributor/distributor-dep.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: distributor
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/ingester/ingester-statefulset.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/ingester/ingester-statefulset.yaml
@@ -31,7 +31,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/instance: mimir
@@ -174,7 +174,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/instance: mimir
@@ -317,7 +317,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: ingester
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/mimir-config.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/mimir-config.yaml
@@ -10,6 +10,7 @@ data:
       external_url: /alertmanager
       fallback_config_file: /configs/alertmanager_fallback_config.yaml
     alertmanager_storage:
+      backend: s3
       s3:
         access_key_id: ${S3_ACCESS_KEY_ID}
         bucket_name: mimir-alertmanager-bucket
@@ -95,6 +96,7 @@ data:
       enable_api: true
       rule_path: /data
     ruler_storage:
+      backend: s3
       s3:
         access_key_id: ${S3_ACCESS_KEY_ID}
         bucket_name: mimir-ruler-bucket

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/overrides-exporter/overrides-exporter-dep.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: overrides-exporter
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/querier/querier-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/querier/querier-dep.yaml
@@ -25,7 +25,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: querier
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/query-frontend/query-frontend-dep.yaml
@@ -24,7 +24,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: query-frontend
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/query-scheduler/query-scheduler-dep.yaml
@@ -27,7 +27,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: query-scheduler
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/ruler/ruler-dep.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/ruler/ruler-dep.yaml
@@ -28,7 +28,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: ruler
         app.kubernetes.io/instance: mimir

--- a/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
+++ b/tests/golden/defaults/mimir/mimir/10_mimir_distributed/mimir-distributed/templates/store-gateway/store-gateway-statefulset.yaml
@@ -30,7 +30,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/instance: mimir
@@ -172,7 +172,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/instance: mimir
@@ -314,7 +314,7 @@ spec:
     metadata:
       annotations:
         bucketSecretVersion: '0'
-        checksum/config: ac579e7442c16c3b4537c7956131985684e98b09290e8bb9cea9bc7116a68fd8
+        checksum/config: 6c6481e85996c18964e926efa4714f8a0730c55921d824719ba3f616ce18dc35
       labels:
         app.kubernetes.io/component: store-gateway
         app.kubernetes.io/instance: mimir


### PR DESCRIPTION
Alertmanagers and rulers were never able to save stuff coming from the API. They wrote to the read-only container file system.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
